### PR TITLE
Use Archiver version 5.0.0 to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archiver-promise",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Promise wrapper for archiver",
   "keywords": [
     "archiver",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/maichong/archiver-promise#readme",
   "dependencies": {
-    "archiver": "^2.1.1"
+    "archiver": "^5.0.0"
   }
 }


### PR DESCRIPTION
```
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Is presented when using `archiver-promise` in its current form. Updating to using the latest version of `archiver` will remove this warning.